### PR TITLE
Ghost Speed IndexOutOfBounds issue fix

### DIFF
--- a/Assets/Scripts/Player/PlayerGhostRun.cs
+++ b/Assets/Scripts/Player/PlayerGhostRun.cs
@@ -213,7 +213,7 @@ public class PlayerGhostRun : MonoBehaviour
         {
             ghostRunner.transform.eulerAngles = Vector3.zero;
             ghostCamera.transform.eulerAngles = pastRunCameraRotationData[currentDataIndex];
-            if (pastRunVelocityData.Length > currentDataIndex)
+            if (pastRunVelocityData != null && pastRunVelocityData.Length >= currentDataIndex)
             {
                 inGameUI.currentSpeed = pastRunVelocityData[currentDataIndex];
             }

--- a/Assets/Scripts/Player/PlayerGhostRun.cs
+++ b/Assets/Scripts/Player/PlayerGhostRun.cs
@@ -213,7 +213,15 @@ public class PlayerGhostRun : MonoBehaviour
         {
             ghostRunner.transform.eulerAngles = Vector3.zero;
             ghostCamera.transform.eulerAngles = pastRunCameraRotationData[currentDataIndex];
-            inGameUI.currentSpeed = pastRunVelocityData[currentDataIndex];
+            if (pastRunVelocityData.Length > currentDataIndex)
+            {
+                inGameUI.currentSpeed = pastRunVelocityData[currentDataIndex];
+            }
+            else
+            {
+                inGameUI.currentSpeed = 0;
+            }
+            
             keyPressed.SetPressed(pastRunKeyData[currentDataIndex]);
         }
         else
@@ -308,10 +316,5 @@ public class PlayerGhostRun : MonoBehaviour
     private bool ShouldGhostBeActive()
     {
         return pastRunPositionData != null && pastRunPositionData.Length > 0 && OptionsPreferencesManager.GetGhostToggle();
-    }
-
-    public float GetGhostVelocity()
-    {
-        return pastRunVelocityData[currentDataIndex];
     }
 }

--- a/Assets/Scripts/UI/InGameUI/InGameUI.cs
+++ b/Assets/Scripts/UI/InGameUI/InGameUI.cs
@@ -68,6 +68,7 @@ public class InGameUI : MonoBehaviour
             completionTimeText.text = time.ToString("hh':'mm':'ss");
         }
 
+        //currentSpeed is by default set to the ghost velocity at this time
         if (!IsGhosting)
         {
             currentSpeed = new Vector2(playerMovement.velocityToApply.x, playerMovement.velocityToApply.z).magnitude;


### PR DESCRIPTION
Fixed an issue where not having the ghost velocity data populated would cause ghost replays to bug out. This should not be needed in the long term, but until we ensure everyone's leaderboard times have this value we need to make it work without it.