### PR TITLE
Fixed null ref thrown in Win Menu when play testing a newly created level in the level editor

### DIFF
--- a/Assets/Scripts/UI/InGameUI/WinMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/WinMenu.cs
@@ -50,8 +50,11 @@ public class WinMenu : MonoBehaviour
             completionTimeText.text = TimeUtils.GetTimeString(GameManager.Instance.currentCompletionTime);
         }
         
-        // Use local best time for now
-        bestTimeText.text = TimeUtils.GetTimeString(currentLevel.levelSaveData.completionTime);
+        if (currentLevel.levelSaveData != null)
+        {
+            // Use local best time for now
+            bestTimeText.text = TimeUtils.GetTimeString(currentLevel.levelSaveData.completionTime);
+        }
 
         // Then work on getting the best time from steam
         float bestTime = await StatsManager.GetLevelCompletionTime(currentLevel.levelName);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/61809127/109391356-8e5e9b80-790e-11eb-967d-050821db1c0f.png)
