### PR TITLE
Patch/timer start

### DIFF
--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -73,6 +73,7 @@ public class PlayerMovement : MonoBehaviour
         controller.Move(velocityToApply * Time.deltaTime);
 
         CheckFootstepSound();
+        CheckFirstMove();
     }
 
     private void OnControllerColliderHit(ControllerColliderHit hit)
@@ -416,6 +417,15 @@ public class PlayerMovement : MonoBehaviour
         if (Input.GetKey(KeyCode.Q))
         {
             transform.position += -cameraMove.playerCamera.transform.up * Time.deltaTime * PlayerConstants.NoClipMoveSpeed;
+        }
+    }
+
+    // This function lets the GameManager know when the player moves to start the timer
+    private void CheckFirstMove()
+    {
+        if(currentInput != Vector3.zero)
+        {
+            GameManager.PlayerFirstMove();
         }
     }
 

--- a/Assets/Scripts/Player/PlayerProgress.cs
+++ b/Assets/Scripts/Player/PlayerProgress.cs
@@ -59,15 +59,6 @@ public class PlayerProgress : MonoBehaviour
         }
     }
 
-    private void OnTriggerExit(Collider other)
-    {
-        Checkpoint checkPointHit = other.gameObject.GetComponent<Checkpoint>();
-        if (checkPointHit && checkPointHit.isFirstCheckpoint)
-        {
-            GameManager.LeftFirstCheckpoint();
-        }
-    }
-
     private void GetFirstCheckpoint()
     {
         Checkpoint[] allCheckpoints = FindObjectsOfType<Checkpoint>();

--- a/Assets/Scripts/Singletons/GameManager.cs
+++ b/Assets/Scripts/Singletons/GameManager.cs
@@ -16,7 +16,7 @@ public class GameManager : MonoBehaviour
     public Level currentLevel;
     public float currentCompletionTime;
     public bool didWinCurrentLevel;
-    public bool hasLeftFirstCheckpoint;
+    public bool hasMoved;
     public bool shouldUseSteam;
     public bool isLoadingScene;
 
@@ -94,7 +94,7 @@ public class GameManager : MonoBehaviour
     {
         SteamClient.RunCallbacks();
 
-        if (!didWinCurrentLevel && hasLeftFirstCheckpoint)
+        if (!didWinCurrentLevel && hasMoved)
         {
             currentCompletionTime += Time.deltaTime;
         }
@@ -166,7 +166,7 @@ public class GameManager : MonoBehaviour
         Debug.Log($"GameManager.Init(): Scene loaded: {scene.name} with index {scene.buildIndex}");
         currentCompletionTime = 0;
         didWinCurrentLevel = false;
-        hasLeftFirstCheckpoint = false;
+        hasMoved = false;
 
         if (!SceneUtils.SceneUsesReplay(scene.buildIndex))
         {
@@ -230,12 +230,12 @@ public class GameManager : MonoBehaviour
     {
         Instance.currentCompletionTime = 0;
         Instance.didWinCurrentLevel = false;
-        Instance.hasLeftFirstCheckpoint = false;
+        Instance.hasMoved = false;
     }
 
-    public static void LeftFirstCheckpoint()
+    public static void PlayerFirstMove()
     {
-        Instance.hasLeftFirstCheckpoint = true;
+        Instance.hasMoved = true;
     }
 
     public static async void FinishedLevel()


### PR DESCRIPTION
We are reworking the starting timer. This update makes it so that the timer doesn't start until the player moves. It used to wait until the player leaves the checkpoint but this was problematic as people could build up speed inside the checkpoint